### PR TITLE
Add ansible learning paths

### DIFF
--- a/packages/app/public/learning-paths/data.json
+++ b/packages/app/public/learning-paths/data.json
@@ -272,5 +272,77 @@
     "description": "For the best experience in this learning path, we suggest that you complete the following learning resources in the order shown. When you click on a resource, it will open in a new tab. Keep this page open so you can easily move on to the next resource!",
     "label": "Using projects in Red Hat OpenShift Data Science",
     "url": "https://developers.redhat.com/learn/openshift-data-science/using-projects-red-hat-openshift-data-science"
+  },
+  {
+    "minutes": 30,
+    "level": "Beginner",
+    "type": "Learning path",
+    "description": "Learn more about the fundamental concepts of Ansible, an open source IT automation solution that automates provisioning, configuration management, application deployment, orchestration, and many other IT processes.",
+    "label": "Introduction to Ansible",
+    "url": "https://red.ht/aap-lp-ansible-basics"
+  },
+  {
+    "hours": 1,
+    "level": "Beginner",
+    "type": "Learning path",
+    "description": "Do a deep-dive into the features of Ansible VS Code extension, the Red Hat recommended way of creating your Ansible projects, which brings syntax-highlighting, auto-completion, linting, and generative AI to your automation creation workflows.",
+    "label": "Getting started with the Ansible VS Code extension",
+    "url": "https://red.ht/aap-lp-vscode-essentials"
+  },
+  {
+    "minutes": 30,
+    "level": "Beginner",
+    "type": "Learning path",
+    "description": "Learn more about YAML and how Ansible Automation Platform uses it for content. YAML offers a straightforward, human-readable way to write Ansible configurations, tasks, and playbooks.",
+    "label": "YAML Essentials for Ansible",
+    "url": "https://red.ht/aap-lp-yaml-essentials"
+  },
+  {
+    "hours": 1,
+    "level": "Beginner",
+    "type": "Learning path",
+    "description": "Learn how to create Ansible playbooks, the blueprints for automation tasks executed across an inventory of nodes. Playbooks tell Ansible which tasks to perform on which devices.",
+    "label": "Getting started with Ansible playbooks",
+    "url": "https://red.ht/aap-lp-getting-started-playbooks"
+  },
+  {
+    "hours": 1,
+    "level": "Intermediate",
+    "type": "Learning path",
+    "description": "Learn more about Ansible Content Collections. Content Collections provide a format for organizing and sharing your Ansible content, such as modules, Playbooks, and documentation.",
+    "label": "Getting started with Content Collections",
+    "link": "https://red.ht/aap-lp-getting-started-collections"
+  },
+  {
+    "minutes": 30,
+    "level": "Beginner",
+    "type": "Lab",
+    "description": "Install ansible-navigator and get hands-on using it.",
+    "label": "Getting started with ansible-navigator",
+    "url": "https://red.ht/aap-lab-getting-started-navigator"
+  },
+  {
+    "minutes": 45,
+    "level": "Beginner",
+    "type": "Lab",
+    "description": "Install ansible-builder and create a custom Execution Environment.",
+    "label": "Getting started with ansible-builder",
+    "url": "https://red.ht/aap-lab-getting-started-builder"
+  },
+  {
+    "hours": 1,
+    "level": "Beginner",
+    "type": "Lab",
+    "description": "Learn the basics of Ansible playbooks and automate basic infrastructure tasks.",
+    "label": "Writing your first playbook",
+    "url": "https://red.ht/aap-lab-getting-started-playbook"
+  },
+  {
+    "minutes": 30,
+    "level": "Beginner",
+    "type": "Lab",
+    "description": "Learn to sign Ansible Content Collections using a Private Automation Hub and install collections with ansible-galaxy CLI.",
+    "label": "Signing Ansible Content Collections with Private Automation Hub",
+    "url": "https://red.ht/aap-lab-sign-collections-with-pah"
   }
 ]


### PR DESCRIPTION
## Description

This PR adds ansible learning paths to `data.json`. 
Once merged these will be visible in learning paths section 
and used to show these in ansible plugin.

## Which issue(s) does this PR fix

# - Fixes #?

## PR acceptance criteria

Please make sure that the following steps are complete:

- [ ] GitHub Actions are completed and successful
- [ ] Unit Tests are updated and passing
- [ ] E2E Tests are updated and passing
- [ ] Documentation is updated if necessary (requirement for new features)
- [ ] Add a screenshot if the change is UX/UI related

## How to test changes / Special notes to the reviewer
